### PR TITLE
Updated critical dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiodns==3.2.0
 aiohappyeyeballs==2.3.5
-aiohttp==3.10.3
+aiohttp==3.11.11
 aiosignal==1.3.1
 annotated-types==0.7.0
 anyio==4.4.0
@@ -16,7 +16,7 @@ Deprecated==1.2.14
 dnspython==2.6.1
 email_validator==2.2.0
 environs==11.0.0
-fastapi==0.112.0
+fastapi==0.115.6
 fastapi-cli==0.0.5
 fastapi_cors==0.0.6
 frozenlist==1.4.1
@@ -36,7 +36,7 @@ httptools==0.6.1
 httpx==0.27.0
 idna==3.7
 importlib_resources==6.4.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 limits==3.13.0
 lxml==5.2.2
 markdown-it-py==3.0.0
@@ -47,6 +47,7 @@ multidict==6.0.5
 orjson==3.10.7
 packaging==24.1
 primp==0.5.5
+propcache==0.2.1
 proto-plus==1.24.0
 protobuf==4.25.4
 pyasn1==0.6.0
@@ -59,7 +60,7 @@ Pygments==2.18.0
 pyparsing==3.1.2
 python-decouple==3.8
 python-dotenv==1.0.1
-python-multipart==0.0.9
+python-multipart==0.0.20
 PyYAML==6.0.2
 requests==2.32.3
 rich==13.7.1
@@ -68,7 +69,7 @@ shellingham==1.5.4
 slowapi==0.1.9
 sniffio==1.3.1
 soupsieve==2.5
-starlette==0.37.2
+starlette==0.41.3
 tqdm==4.66.5
 typer==0.12.3
 typing_extensions==4.12.2
@@ -80,4 +81,4 @@ uvloop==0.19.0
 watchfiles==0.23.0
 websockets==12.0
 wrapt==1.16.0
-yarl==1.9.4
+yarl==1.18.3


### PR DESCRIPTION
Updated starlette, aiohttp, python-multipart and Jinja2 as vulnerabilities were discovered in older versions